### PR TITLE
[week6] 프로그래머스 - 캐시 문제 해결

### DIFF
--- a/src/main/java/week6/Solution.java
+++ b/src/main/java/week6/Solution.java
@@ -4,9 +4,41 @@
  */
 package week6;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
 class Solution {
     public int solution(int cacheSize, String[] cities) {
         int answer = 0;
+        Queue<City> queue = new LinkedList<>();
+        for (int i = 0; i < cities.length; i++) {
+
+            if (queue.contains(new City(cities[i]))) {
+                answer++;
+            } else {
+                if (queue.size() >= cacheSize) {
+                    queue.poll();
+                }
+                queue.offer(new City(cities[i]));
+                answer += 5;
+            }
+        }
         return answer;
+    }
+}
+
+class City {
+    String name;
+
+    public City(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        City city = (City) o;
+        return name.toUpperCase().equals(city.name.toUpperCase());
     }
 }

--- a/src/test/java/week5/SolutionTest.java
+++ b/src/test/java/week5/SolutionTest.java
@@ -1,7 +1,6 @@
 package week5;
 
 import org.junit.jupiter.api.Test;
-import sun.jvm.hotspot.utilities.Assert;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
1. City Class에 대소문자 구분 없이 city의 이름을 확인할  equals 메서드를 추가합니다.
2. cities를 for문으로 돌면서 큐에 City가 있는지 확인합니다
    - 큐(캐시)에 city가 있을 경우 answer는 1만 올려줍니다.
    - 큐(캐시)에 city가 없을 경우, queue에 City를 올려주고 answer를 5 증가시킵니다. 이 때, 큐의 사이즈가 cache의 Size와 같아지면 queue에서 city를 하나 뺍니다.